### PR TITLE
Fix electron-builder package vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@types/node": "^20.11.16",
         "concurrently": "^8.2.2",
         "electron": "^28.2.2",
-        "electron-builder": "^24.12.0",
+        "electron-builder": "^24.13.3",
         "nodemon": "^3.0.3",
         "typescript": "^5.3.3"
     }


### PR DESCRIPTION
- Fix electron-builder latest [vulnerability](https://github.com/advisories/GHSA-r4pf-3v7r-hh55) to prevent attackers from running malicious executables on Windows machines.